### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/sync-all.yml
+++ b/.github/workflows/sync-all.yml
@@ -17,7 +17,7 @@ jobs:
               env:
                 OUTPUT: ${{ steps.repos.outputs.npm-packages }}
             - name: Sync NPM Token
-              uses: google/secrets-sync-action@master
+              uses: jpoehnelt/secrets-sync-action@master
               with:
                   secrets: |
                       ^NPM_TOKEN$
@@ -29,7 +29,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GH_TOKEN: ${{ secrets.SYNC_GITHUB_TOKEN }}
             - name: Sync VSCE & OVSX Tokens (PAT)
-              uses: google/secrets-sync-action@master
+              uses: jpoehnelt/secrets-sync-action@master
               with:
                   secrets: |
                       ^VSCE_PAT$


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.